### PR TITLE
WIP: Transform for F# Pipeline

### DIFF
--- a/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/buildOptimizedSequenceExpression.js
@@ -6,42 +6,48 @@ import { types as t } from "@babel/core";
 //   (a = b, a + e)
 const buildOptimizedSequenceExpression = ({ assign, call, path }) => {
   const { left: placeholderNode, right: pipelineLeft } = assign;
-  const { callee: calledExpression } = call;
+  const { callee: pipelineRight } = call;
 
   let optimizeArrow =
-    t.isArrowFunctionExpression(calledExpression) &&
-    t.isExpression(calledExpression.body) &&
-    !calledExpression.async &&
-    !calledExpression.generator;
+    t.isArrowFunctionExpression(pipelineRight) &&
+    t.isExpression(pipelineRight.body) &&
+    !pipelineRight.async &&
+    !pipelineRight.generator;
   let param;
 
   if (optimizeArrow) {
-    const { params } = calledExpression;
+    const { params } = pipelineRight;
     if (params.length === 1 && t.isIdentifier(params[0])) {
       param = params[0];
     } else if (params.length > 0) {
       optimizeArrow = false;
     }
-  } else if (t.isIdentifier(calledExpression, { name: "eval" })) {
+  } else if (t.isIdentifier(pipelineRight, { name: "eval" })) {
     const evalSequence = t.sequenceExpression([
       t.numericLiteral(0),
-      calledExpression,
+      pipelineRight,
     ]);
 
     call.callee = evalSequence;
 
     return t.sequenceExpression([assign, call]);
+  } else if (
+    (t.isIdentifier(pipelineRight) &&
+      path.scope.hasBinding(pipelineRight.name)) ||
+    t.isImmutable(pipelineLeft)
+  ) {
+    return t.callExpression(pipelineRight, [pipelineLeft]);
   }
 
   if (optimizeArrow && !param) {
     // Arrow function with 0 arguments
-    return t.sequenceExpression([pipelineLeft, calledExpression.body]);
+    return t.sequenceExpression([pipelineLeft, pipelineRight.body]);
   }
 
   if (param) {
     path.get("right").scope.rename(param.name, placeholderNode.name);
 
-    return t.sequenceExpression([assign, calledExpression.body]);
+    return t.sequenceExpression([assign, pipelineRight.body]);
   }
 
   return t.sequenceExpression([assign, call]);

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -1,0 +1,55 @@
+import { types as t } from "@babel/core";
+
+const fsharpVisitor = {
+  BinaryExpression(path) {
+    const { scope } = path;
+    const { node } = path;
+    const { operator, left } = node;
+    let { right } = node;
+    if (operator !== "|>") return;
+
+    let optimizeArrow =
+      t.isArrowFunctionExpression(right) &&
+      t.isExpression(right.body) &&
+      !right.async &&
+      !right.generator;
+    let param;
+
+    if (optimizeArrow) {
+      const { params } = right;
+      if (params.length === 1 && t.isIdentifier(params[0])) {
+        param = params[0];
+      } else if (params.length > 0) {
+        optimizeArrow = false;
+      }
+    } else if (t.isIdentifier(right, { name: "eval" })) {
+      right = t.sequenceExpression([t.numericLiteral(0), right]);
+    }
+
+    if (optimizeArrow && !param) {
+      // Arrow function with 0 arguments
+      path.replaceWith(t.sequenceExpression([left, right.body]));
+      return;
+    }
+
+    const placeholder = scope.generateUidIdentifierBasedOnNode(param || left);
+    scope.push({ id: placeholder });
+    if (param) {
+      path.get("right").scope.rename(param.name, placeholder.name);
+    }
+
+    const applied =
+      right.type === "AwaitExpression"
+        ? t.awaitExpression(t.cloneNode(placeholder))
+        : t.callExpression(right, [t.cloneNode(placeholder)]);
+    const call = optimizeArrow ? right.body : applied;
+    path.replaceWith(
+      t.sequenceExpression([
+        t.assignmentExpression("=", t.cloneNode(placeholder), left),
+        call,
+      ]),
+    );
+  },
+};
+
+export default fsharpVisitor;

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -1,54 +1,74 @@
 import { types as t } from "@babel/core";
 
+// tries to optimize sequence expressions in the format
+//   (a = b, ((c) => d + e)(a))
+// to
+//   (a = b, a + e)
+const maybeOptimizePipelineSequence = path => {
+  const [assignNode, callNode] = path.node.expressions;
+  const { left: placeholderNode, right: pipelineLeft } = assignNode;
+  const { callee: calledExpression } = callNode;
+
+  let optimizeArrow =
+    t.isArrowFunctionExpression(calledExpression) &&
+    t.isExpression(calledExpression.body) &&
+    !calledExpression.async &&
+    !calledExpression.generator;
+  let param;
+
+  if (optimizeArrow) {
+    const { params } = calledExpression;
+    if (params.length === 1 && t.isIdentifier(params[0])) {
+      param = params[0];
+    } else if (params.length > 0) {
+      optimizeArrow = false;
+    }
+  } else if (t.isIdentifier(calledExpression, { name: "eval" })) {
+    const evalSequence = t.sequenceExpression([
+      t.numericLiteral(0),
+      calledExpression,
+    ]);
+
+    path.get("expressions.1.callee").replaceWith(evalSequence);
+  }
+
+  if (optimizeArrow && !param) {
+    // Arrow function with 0 arguments
+    path.replaceWith(
+      t.sequenceExpression([pipelineLeft, calledExpression.body]),
+    );
+    return;
+  }
+
+  if (param) {
+    path
+      .get("expressions.1.callee.body")
+      .scope.rename(param.name, placeholderNode.name);
+    path.get("expressions.1").replaceWith(calledExpression.body);
+  }
+};
+
 const fsharpVisitor = {
   BinaryExpression(path) {
     const { scope } = path;
     const { node } = path;
-    const { operator, left } = node;
-    let { right } = node;
+    const { operator, left, right } = node;
     if (operator !== "|>") return;
 
-    let optimizeArrow =
-      t.isArrowFunctionExpression(right) &&
-      t.isExpression(right.body) &&
-      !right.async &&
-      !right.generator;
-    let param;
-
-    if (optimizeArrow) {
-      const { params } = right;
-      if (params.length === 1 && t.isIdentifier(params[0])) {
-        param = params[0];
-      } else if (params.length > 0) {
-        optimizeArrow = false;
-      }
-    } else if (t.isIdentifier(right, { name: "eval" })) {
-      right = t.sequenceExpression([t.numericLiteral(0), right]);
-    }
-
-    if (optimizeArrow && !param) {
-      // Arrow function with 0 arguments
-      path.replaceWith(t.sequenceExpression([left, right.body]));
-      return;
-    }
-
-    const placeholder = scope.generateUidIdentifierBasedOnNode(param || left);
+    const placeholder = scope.generateUidIdentifierBasedOnNode(left);
     scope.push({ id: placeholder });
-    if (param) {
-      path.get("right").scope.rename(param.name, placeholder.name);
-    }
 
     const applied =
       right.type === "AwaitExpression"
         ? t.awaitExpression(t.cloneNode(placeholder))
         : t.callExpression(right, [t.cloneNode(placeholder)]);
-    const call = optimizeArrow ? right.body : applied;
-    path.replaceWith(
-      t.sequenceExpression([
-        t.assignmentExpression("=", t.cloneNode(placeholder), left),
-        call,
-      ]),
-    );
+    const call = applied;
+    const sequence = t.sequenceExpression([
+      t.assignmentExpression("=", t.cloneNode(placeholder), left),
+      call,
+    ]);
+    path.replaceWith(sequence);
+    maybeOptimizePipelineSequence(path);
   },
 };
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -3,8 +3,7 @@ import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
 
 const fsharpVisitor = {
   BinaryExpression(path) {
-    const { scope } = path;
-    const { node } = path;
+    const { scope, node } = path;
     const { operator, left, right } = node;
     if (operator !== "|>") return;
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -1,52 +1,5 @@
 import { types as t } from "@babel/core";
-
-// tries to optimize sequence expressions in the format
-//   (a = b, ((c) => d + e)(a))
-// to
-//   (a = b, a + e)
-const maybeOptimizePipelineSequence = path => {
-  const [assignNode, callNode] = path.node.expressions;
-  const { left: placeholderNode, right: pipelineLeft } = assignNode;
-  const { callee: calledExpression } = callNode;
-
-  let optimizeArrow =
-    t.isArrowFunctionExpression(calledExpression) &&
-    t.isExpression(calledExpression.body) &&
-    !calledExpression.async &&
-    !calledExpression.generator;
-  let param;
-
-  if (optimizeArrow) {
-    const { params } = calledExpression;
-    if (params.length === 1 && t.isIdentifier(params[0])) {
-      param = params[0];
-    } else if (params.length > 0) {
-      optimizeArrow = false;
-    }
-  } else if (t.isIdentifier(calledExpression, { name: "eval" })) {
-    const evalSequence = t.sequenceExpression([
-      t.numericLiteral(0),
-      calledExpression,
-    ]);
-
-    path.get("expressions.1.callee").replaceWith(evalSequence);
-  }
-
-  if (optimizeArrow && !param) {
-    // Arrow function with 0 arguments
-    path.replaceWith(
-      t.sequenceExpression([pipelineLeft, calledExpression.body]),
-    );
-    return;
-  }
-
-  if (param) {
-    path
-      .get("expressions.1.callee.body")
-      .scope.rename(param.name, placeholderNode.name);
-    path.get("expressions.1").replaceWith(calledExpression.body);
-  }
-};
+import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
 
 const fsharpVisitor = {
   BinaryExpression(path) {
@@ -58,11 +11,10 @@ const fsharpVisitor = {
     const placeholder = scope.generateUidIdentifierBasedOnNode(left);
     scope.push({ id: placeholder });
 
-    const applied =
+    const call =
       right.type === "AwaitExpression"
         ? t.awaitExpression(t.cloneNode(placeholder))
         : t.callExpression(right, [t.cloneNode(placeholder)]);
-    const call = applied;
     const sequence = t.sequenceExpression([
       t.assignmentExpression("=", t.cloneNode(placeholder), left),
       call,

--- a/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/fsharpVisitor.js
@@ -1,5 +1,5 @@
 import { types as t } from "@babel/core";
-import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
+import buildOptimizedSequenceExpression from "./buildOptimizedSequenceExpression";
 
 const fsharpVisitor = {
   BinaryExpression(path) {
@@ -14,12 +14,12 @@ const fsharpVisitor = {
       right.type === "AwaitExpression"
         ? t.awaitExpression(t.cloneNode(placeholder))
         : t.callExpression(right, [t.cloneNode(placeholder)]);
-    const sequence = t.sequenceExpression([
-      t.assignmentExpression("=", t.cloneNode(placeholder), left),
+    const sequence = buildOptimizedSequenceExpression({
+      assign: t.assignmentExpression("=", t.cloneNode(placeholder), left),
       call,
-    ]);
+      path,
+    });
     path.replaceWith(sequence);
-    maybeOptimizePipelineSequence(path);
   },
 };
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/index.js
@@ -2,10 +2,12 @@ import { declare } from "@babel/helper-plugin-utils";
 import syntaxPipelineOperator from "@babel/plugin-syntax-pipeline-operator";
 import minimalVisitor from "./minimalVisitor";
 import smartVisitor from "./smartVisitor";
+import fsharpVisitor from "./fsharpVisitor";
 
 const visitorsPerProposal = {
   minimal: minimalVisitor,
   smart: smartVisitor,
+  fsharp: fsharpVisitor,
 };
 
 export default declare((api, options) => {

--- a/packages/babel-plugin-proposal-pipeline-operator/src/maybeOptimizePipelineSequence.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/maybeOptimizePipelineSequence.js
@@ -1,0 +1,51 @@
+import { types as t } from "@babel/core";
+
+// tries to optimize sequence expressions in the format
+//   (a = b, ((c) => d + e)(a))
+// to
+//   (a = b, a + e)
+const maybeOptimizePipelineSequence = path => {
+  const [assignNode, callNode] = path.node.expressions;
+  const { left: placeholderNode, right: pipelineLeft } = assignNode;
+  const { callee: calledExpression } = callNode;
+
+  let optimizeArrow =
+    t.isArrowFunctionExpression(calledExpression) &&
+    t.isExpression(calledExpression.body) &&
+    !calledExpression.async &&
+    !calledExpression.generator;
+  let param;
+
+  if (optimizeArrow) {
+    const { params } = calledExpression;
+    if (params.length === 1 && t.isIdentifier(params[0])) {
+      param = params[0];
+    } else if (params.length > 0) {
+      optimizeArrow = false;
+    }
+  } else if (t.isIdentifier(calledExpression, { name: "eval" })) {
+    const evalSequence = t.sequenceExpression([
+      t.numericLiteral(0),
+      calledExpression,
+    ]);
+
+    path.get("expressions.1.callee").replaceWith(evalSequence);
+  }
+
+  if (optimizeArrow && !param) {
+    // Arrow function with 0 arguments
+    path.replaceWith(
+      t.sequenceExpression([pipelineLeft, calledExpression.body]),
+    );
+    return;
+  }
+
+  if (param) {
+    path
+      .get("expressions.1.callee.body")
+      .scope.rename(param.name, placeholderNode.name);
+    path.get("expressions.1").replaceWith(calledExpression.body);
+  }
+};
+
+export default maybeOptimizePipelineSequence;

--- a/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
@@ -3,8 +3,7 @@ import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
 
 const minimalVisitor = {
   BinaryExpression(path) {
-    const { scope } = path;
-    const { node } = path;
+    const { scope, node } = path;
     const { operator, left, right } = node;
     if (operator !== "|>") return;
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
@@ -1,52 +1,24 @@
 import { types as t } from "@babel/core";
+import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
 
 const minimalVisitor = {
   BinaryExpression(path) {
     const { scope } = path;
     const { node } = path;
-    const { operator, left } = node;
-    let { right } = node;
+    const { operator, left, right } = node;
     if (operator !== "|>") return;
 
-    let optimizeArrow =
-      t.isArrowFunctionExpression(right) &&
-      t.isExpression(right.body) &&
-      !right.async &&
-      !right.generator;
-    let param;
-
-    if (optimizeArrow) {
-      const { params } = right;
-      if (params.length === 1 && t.isIdentifier(params[0])) {
-        param = params[0];
-      } else if (params.length > 0) {
-        optimizeArrow = false;
-      }
-    } else if (t.isIdentifier(right, { name: "eval" })) {
-      right = t.sequenceExpression([t.numericLiteral(0), right]);
-    }
-
-    if (optimizeArrow && !param) {
-      // Arrow function with 0 arguments
-      path.replaceWith(t.sequenceExpression([left, right.body]));
-      return;
-    }
-
-    const placeholder = scope.generateUidIdentifierBasedOnNode(param || left);
+    const placeholder = scope.generateUidIdentifierBasedOnNode(left);
     scope.push({ id: placeholder });
-    if (param) {
-      path.get("right").scope.rename(param.name, placeholder.name);
-    }
 
-    const call = optimizeArrow
-      ? right.body
-      : t.callExpression(right, [t.cloneNode(placeholder)]);
+    const call = t.callExpression(right, [t.cloneNode(placeholder)]);
     path.replaceWith(
       t.sequenceExpression([
         t.assignmentExpression("=", t.cloneNode(placeholder), left),
         call,
       ]),
     );
+    maybeOptimizePipelineSequence(path);
   },
 };
 

--- a/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/src/minimalVisitor.js
@@ -1,5 +1,5 @@
 import { types as t } from "@babel/core";
-import maybeOptimizePipelineSequence from "./maybeOptimizePipelineSequence";
+import buildOptimizedSequenceExpression from "./buildOptimizedSequenceExpression";
 
 const minimalVisitor = {
   BinaryExpression(path) {
@@ -12,12 +12,12 @@ const minimalVisitor = {
 
     const call = t.callExpression(right, [t.cloneNode(placeholder)]);
     path.replaceWith(
-      t.sequenceExpression([
-        t.assignmentExpression("=", t.cloneNode(placeholder), left),
+      buildOptimizedSequenceExpression({
+        assign: t.assignmentExpression("=", t.cloneNode(placeholder), left),
         call,
-      ]),
+        path,
+      }),
     );
-    maybeOptimizePipelineSequence(path);
   },
 };
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions-parenless/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions-parenless/exec.js
@@ -1,0 +1,34 @@
+const y = 2;
+
+const f = (x) => (x
+  |> (y) => y + 1)
+  |> (z) => z * y
+
+const _f = (x) => x
+  |> (y) => y + 1
+  |> (z) => z * y
+
+const g = (x) => x
+  |> (y) => (
+    y + 1
+    |> (z) => z * y
+  )
+
+const _g = (x) => x
+  |> (y => (
+    y + 1
+    |> (z) => z * y)
+  )
+
+const __g = (x) => x
+  |> (y => { return (
+    y + 1
+    |> (z) => z * y);
+    }
+  )
+
+expect(  f(1)).toBe(4);
+expect( _f(1)).toBe(4);
+expect(  g(1)).toBe(2);
+expect( _g(1)).toBe(2);
+expect(__g(1)).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions-parenless/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions-parenless/exec.js
@@ -1,7 +1,6 @@
 const y = 2;
 
-const f = (x) => (x
-  |> (y) => y + 1)
+const f = (x) => (x |> (y) => y + 1)
   |> (z) => z * y
 
 const _f = (x) => x
@@ -9,21 +8,15 @@ const _f = (x) => x
   |> (z) => z * y
 
 const g = (x) => x
-  |> (y) => (
-    y + 1
-    |> (z) => z * y
-  )
+  |> (y) => (y + 1 |> (z) => z * y)
 
 const _g = (x) => x
-  |> (y => (
-    y + 1
-    |> (z) => z * y)
-  )
+  |> (y => (y + 1 |> (z) => z * y))
 
 const __g = (x) => x
-  |> (y => { return (
-    y + 1
-    |> (z) => z * y);
+  |> (
+    y => {
+      return (y + 1 |> (z) => z * y);
     }
   )
 

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/exec.js
@@ -1,0 +1,14 @@
+var result = [5,10]
+  |> (_ => _.map(x => x * 2))
+  |> (_ => _.reduce( (a,b) => a + b ))
+  |> (sum => sum + 1)
+
+expect(result).toBe(31);
+
+
+var inc = (x) => x + 1;
+var double = (x) => x * 2;
+
+var result2 = [4, 9].map( x => x |> inc |> double )
+
+expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/input.js
@@ -1,0 +1,14 @@
+var result = [5,10]
+  |> (_ => _.map(x => x * 2))
+  |> (_ => _.reduce( (a,b) => a + b ))
+  |> (sum => sum + 1)
+
+expect(result).toBe(31);
+
+
+var inc = (x) => x + 1;
+var double = (x) => x * 2;
+
+var result2 = [4, 9].map( x => x |> inc |> double )
+
+expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
@@ -1,0 +1,15 @@
+var _sum, _ref, _ref2;
+
+var result = (_sum = (_ref = (_ref2 = [5, 10], _ref2.map(x => x * 2)), _ref.reduce((a, b) => a + b)), _sum + 1);
+expect(result).toBe(31);
+
+var inc = x => x + 1;
+
+var double = x => x * 2;
+
+var result2 = [4, 9].map(x => {
+  var _ref3, _x;
+
+  return _ref3 = (_x = x, inc(_x)), double(_ref3);
+});
+expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
@@ -1,6 +1,6 @@
-var _sum, _ref, _ref2;
+var _ref, _ref2, _ref3;
 
-var result = (_sum = (_ref = (_ref2 = [5, 10], _ref2.map(x => x * 2)), _ref.reduce((a, b) => a + b)), _sum + 1);
+var result = (_ref = (_ref2 = (_ref3 = [5, 10], _ref3.map(x => x * 2)), _ref2.reduce((a, b) => a + b)), _ref + 1);
 expect(result).toBe(31);
 
 var inc = x => x + 1;
@@ -8,8 +8,8 @@ var inc = x => x + 1;
 var double = x => x * 2;
 
 var result2 = [4, 9].map(x => {
-  var _ref3, _x;
+  var _ref4, _x;
 
-  return _ref3 = (_x = x, inc(_x)), double(_ref3);
+  return _ref4 = (_x = x, inc(_x)), double(_ref4);
 });
 expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/arrow-functions/output.js
@@ -10,6 +10,6 @@ var double = x => x * 2;
 var result2 = [4, 9].map(x => {
   var _ref4, _x;
 
-  return _ref4 = (_x = x, inc(_x)), double(_ref4);
+  return double(inc(x));
 });
 expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/exec.js
@@ -1,0 +1,13 @@
+const triple = (x) => x * 3;
+
+async function myFunction(n) {
+  return n
+    |> Math.abs
+    |> Promise.resolve
+    |> await
+    |> triple;
+}
+
+return myFunction(-7).then(result => {
+  expect(result).toBe(21);
+});

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/input.js
@@ -1,0 +1,6 @@
+async function myFunction(n) {
+  return n
+    |> Math.abs
+    |> Promise.resolve
+    |> await;
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/options.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    ["proposal-pipeline-operator", { "proposal": "fsharp" }]
+  ],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  },
+  "minNodeVersion": "8.0.0"
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/await/output.js
@@ -1,0 +1,5 @@
+async function myFunction(n) {
+  var _ref, _ref2, _n;
+
+  return _ref = (_ref2 = (_n = n, Math.abs(_n)), Promise.resolve(_ref2)), await _ref;
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/exec.js
@@ -1,0 +1,3 @@
+var inc = (x) => x + 1
+
+expect(10 |> inc).toBe(11);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/input.js
@@ -1,0 +1,3 @@
+var inc = (x) => x + 1
+
+expect(10 |> inc).toBe(11);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/output.js
@@ -1,0 +1,5 @@
+var _;
+
+var inc = x => x + 1;
+
+expect((_ = 10, inc(_))).toBe(11);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/basic/output.js
@@ -2,4 +2,4 @@ var _;
 
 var inc = x => x + 1;
 
-expect((_ = 10, inc(_))).toBe(11);
+expect(inc(10)).toBe(11);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/exec.js
@@ -1,0 +1,7 @@
+(function() {
+  'use strict';
+  var result = '(function() { return this; })()'
+    |> eval;
+
+  expect(result).not.toBeUndefined();
+})();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/input.js
@@ -1,0 +1,7 @@
+(function() {
+  'use strict';
+  var result = '(function() { return this; })()'
+    |> eval;
+
+  expect(result).not.toBeUndefined();
+})();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/indirect-eval/output.js
@@ -1,0 +1,8 @@
+(function () {
+  'use strict';
+
+  var _functionReturn;
+
+  var result = (_functionReturn = '(function() { return this; })()', (0, eval)(_functionReturn));
+  expect(result).not.toBeUndefined();
+})();

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/multiple-argument-use/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/multiple-argument-use/input.js
@@ -1,0 +1,5 @@
+var array = [10,20,30];
+
+var last = array |> (a => a[a.length-1]);
+
+expect(last).toBe(30);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/multiple-argument-use/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/multiple-argument-use/output.js
@@ -1,0 +1,5 @@
+var _array;
+
+var array = [10, 20, 30];
+var last = (_array = array, _array[_array.length - 1]);
+expect(last).toBe(30);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/exec.js
@@ -1,0 +1,8 @@
+var a = 1,
+    b = 2,
+    c = 3;
+var result = a
+  |> (() => b)
+  |> (() => c);
+
+expect(result).toBe(c);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/input.js
@@ -1,0 +1,8 @@
+var a = 1,
+    b = 2,
+    c = 3;
+var result = a
+  |> (() => b)
+  |> (() => c);
+
+expect(result).toBe(c);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/output.js
@@ -1,0 +1,5 @@
+var a = 1,
+    b = 2,
+    c = 3;
+var result = ((a, b), c);
+expect(result).toBe(c);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/optimize-0-param-arrow/output.js
@@ -1,3 +1,5 @@
+var _ref, _a;
+
 var a = 1,
     b = 2,
     c = 3;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/options.json
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/fsharp/options.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    ["proposal-pipeline-operator", { "proposal": "fsharp" }]
+  ],
+  "parserOpts": {
+    "allowReturnOutsideFunction": true
+  }
+}

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/exec.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/exec.js
@@ -1,0 +1,20 @@
+const y = 2;
+const f = (x) => x
+  |> (y => y + 1)
+  |> (z => z * y)
+
+const g = (x) => x
+  |> (y =>
+    y + 1
+    |> (z => z * y)
+  )
+
+const h = (x) => x
+  |> (y => (
+    y + 1
+    |> (z => z * y)
+  ))
+
+expect(f(1)).toBe(4);
+expect(g(1)).toBe(2);
+expect(h(1)).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/input.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/input.js
@@ -1,0 +1,20 @@
+const y = 2;
+const f = (x) => x
+  |> (y => y + 1)
+  |> (z => z * y)
+
+const g = (x) => x
+  |> (y =>
+    y + 1
+    |> (z => z * y)
+  )
+
+const h = (x) => x
+  |> (y => (
+    y + 1
+    |> (z => z * y)
+  ))
+
+expect(f(1)).toBe(4);
+expect(g(1)).toBe(2);
+expect(h(1)).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/output.js
@@ -1,0 +1,23 @@
+const y = 2;
+
+const f = x => {
+  var _z, _y;
+
+  return _z = (_y = x, _y + 1), _z * y;
+};
+
+const g = x => {
+  var _y2, _z2;
+
+  return _y2 = x, (_z2 = _y2 + 1, _z2 * _y2);
+};
+
+const h = x => {
+  var _y3, _z3;
+
+  return _y3 = x, (_z3 = _y3 + 1, _z3 * _y3);
+};
+
+expect(f(1)).toBe(4);
+expect(g(1)).toBe(2);
+expect(h(1)).toBe(2);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions-parenless/output.js
@@ -1,21 +1,21 @@
 const y = 2;
 
 const f = x => {
-  var _z, _y;
+  var _ref, _x;
 
-  return _z = (_y = x, _y + 1), _z * y;
+  return _ref = (_x = x, _x + 1), _ref * y;
 };
 
 const g = x => {
-  var _y2, _z2;
+  var _x2, _ref2;
 
-  return _y2 = x, (_z2 = _y2 + 1, _z2 * _y2);
+  return _x2 = x, (_ref2 = _x2 + 1, _ref2 * _x2);
 };
 
 const h = x => {
-  var _y3, _z3;
+  var _x3, _ref3;
 
-  return _y3 = x, (_z3 = _y3 + 1, _z3 * _y3);
+  return _x3 = x, (_ref3 = _x3 + 1, _ref3 * _x3);
 };
 
 expect(f(1)).toBe(4);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions/output.js
@@ -1,6 +1,6 @@
-var _sum, _ref, _ref2;
+var _ref, _ref2, _ref3;
 
-var result = (_sum = (_ref = (_ref2 = [5, 10], _ref2.map(x => x * 2)), _ref.reduce((a, b) => a + b)), _sum + 1);
+var result = (_ref = (_ref2 = (_ref3 = [5, 10], _ref3.map(x => x * 2)), _ref2.reduce((a, b) => a + b)), _ref + 1);
 expect(result).toBe(31);
 
 var inc = x => x + 1;
@@ -8,8 +8,8 @@ var inc = x => x + 1;
 var double = x => x * 2;
 
 var result2 = [4, 9].map(x => {
-  var _ref3, _x;
+  var _ref4, _x;
 
-  return _ref3 = (_x = x, inc(_x)), double(_ref3);
+  return _ref4 = (_x = x, inc(_x)), double(_ref4);
 });
 expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/arrow-functions/output.js
@@ -10,6 +10,6 @@ var double = x => x * 2;
 var result2 = [4, 9].map(x => {
   var _ref4, _x;
 
-  return _ref4 = (_x = x, inc(_x)), double(_ref4);
+  return double(inc(x));
 });
 expect(result2).toEqual([10, 20]);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/async-arrow/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/async-arrow/output.js
@@ -6,7 +6,7 @@ function then(fn) {
   };
 }
 
-var result = (_ref = (_ = 1, (async x => (await x) + 1)(_)), then(x => x + 1)(_ref));
+var result = (_ref = (async x => (await x) + 1)(1), then(x => x + 1)(_ref));
 result.then(val => {
   expect(val).toBe(3);
 });

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/basic/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/basic/output.js
@@ -2,4 +2,4 @@ var _;
 
 var inc = x => x + 1;
 
-expect((_ = 10, inc(_))).toBe(11);
+expect(inc(10)).toBe(11);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/chaining/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/chaining/output.js
@@ -4,4 +4,4 @@ var inc = x => x + 1;
 
 var double = x => x * 2;
 
-expect((_ref = (_ = 10, inc(_)), double(_ref))).toBe(22);
+expect(double(inc(10))).toBe(22);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/multiple-argument-use/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/multiple-argument-use/output.js
@@ -1,5 +1,5 @@
-var _a;
+var _array;
 
 var array = [10, 20, 30];
-var last = (_a = array, _a[_a.length - 1]);
+var last = (_array = array, _array[_array.length - 1]);
 expect(last).toBe(30);

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/optimize-0-param-arrow/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/optimize-0-param-arrow/output.js
@@ -1,3 +1,5 @@
+var _ref, _a;
+
 var a = 1,
     b = 2,
     c = 3;

--- a/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/precedence/output.js
+++ b/packages/babel-plugin-proposal-pipeline-operator/test/fixtures/minimal/precedence/output.js
@@ -2,12 +2,12 @@ var _ref, _ref2, _;
 
 var inc = x => x + 1;
 
-var result = (_ref = 4 || 9, inc(_ref));
+var result = inc(4 || 9);
 expect(result).toBe(5);
 
 var f = x => x + 10;
 
 var h = x => x + 20;
 
-var result2 = (_ref2 = (_ = 10, (f || h)(_)), inc(_ref2));
+var result2 = inc((f || h)(10));
 expect(result2).toBe(21);

--- a/packages/babel-plugin-syntax-pipeline-operator/src/index.js
+++ b/packages/babel-plugin-syntax-pipeline-operator/src/index.js
@@ -1,6 +1,6 @@
 import { declare } from "@babel/helper-plugin-utils";
 
-export const proposals = ["minimal", "smart"];
+export const proposals = ["minimal", "smart", "fsharp"];
 
 export default declare((api, { proposal }) => {
   api.assertVersion(7);


### PR DESCRIPTION
<!--
Before making a PR, please read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. (it should be underlined in the preview if done correctly)

If you are making a change that should have a docs update: submit another PR to https://github.com/babel/website
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | 
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      | Yes
| Tests Added + Pass?      | Yes
| Documentation PR Link    | 
| Any Dependency Changes?  | No
| License                  | MIT

This is a transform for the F# proposal of the pipeline operator based on @mAAdhaTTah's parsing code.

It is basically the minimal visitor with support for paramless await. The most relevant lines are fsharpVisitor.js/44-47

TODO:

- [x] dedup optimization logic between minimal and fsharp
- [x] integration tests for paren-less arrow functions
- [x] eliminate temp _ref vars from optimized outputs
- [ ] the name buildOptmizedSequenceExpression is misleading. it returns call expressions sometimes. fix that.